### PR TITLE
Allow sending options to puppeteer.launch()

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function Walker () {
 
 Walker.prototype = Object.create(EventEmitter.prototype)
 
-Walker.prototype.walk = async function (initialHref) {
+Walker.prototype.walk = async function (initialHref, options) {
   assert.equal(typeof initialHref, 'string', 'puppeteer-walker.walk: initialHref needs to be type string')
 
   var url = new URL(initialHref)
@@ -29,7 +29,7 @@ Walker.prototype.walk = async function (initialHref) {
   var visited = new Set()
 
   try {
-    var browser = await puppeteer.launch()
+    var browser = await puppeteer.launch(options || {})
     var page = await browser.newPage()
   } catch (err) {
     this.emit('error', err)


### PR DESCRIPTION
This allows sending an `options` object into `puppeteer.launch()`

See https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions for more information.